### PR TITLE
Stream: expose --stream-chunk-sec

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ These limits activate automatically when the stream is long enough to exceed the
 `--stream --silent` has a special non-interactive behavior for file input: it skips chunk-by-chunk streaming and runs one direct final refinement pass. (For live stdin streaming, chunked mode is still used.)
 
 Default stream settings:
-- `chunk_size`: 2s
+- `chunk_size`: 2s (`--stream-chunk-sec`, range `1..8`)
 - `encoder_window`: 8s (`--enc-window-sec`, range `1..8`)
 - `rollback`: 5 tokens
 - `unfixed_chunks`: 2
@@ -126,12 +126,29 @@ Streaming tuning:
 # default streaming
 ./qwen_asr -d qwen3-asr-0.6b -i audio.wav --stream
 
-# lower-latency encoder window (may reduce quality)
+# larger chunk for 1.7B / slower hardware (see notes below)
+./qwen_asr -d qwen3-asr-1.7b -i audio.wav --stream --stream-chunk-sec 4
+
+# narrower encoder window (less compute per chunk; may reduce quality)
 ./qwen_asr -d qwen3-asr-0.6b -i audio.wav --stream --enc-window-sec 4
 
 # allow more text generation per chunk
 ./qwen_asr -d qwen3-asr-0.6b -i audio.wav --stream --stream-max-new-tokens 64
 ```
+
+Picking `--stream-chunk-sec`:
+
+The default 2s matches the official Qwen3-ASR vLLM streaming example. On
+**Apple M1 Pro**, 0.6B processes ~0.8s per chunk so 2s has plenty of headroom.
+1.7B takes ~1.5-2s, right at the 2s budget, and a real-time stream backlogs
+over time. Raising 1.7B to `chunk_sec=4` adds 2s to per-chunk delay but
+eliminates the backlog — net on-screen latency **drops** by several seconds.
+
+If realtime ratio approaches 1x, raise `--stream-chunk-sec` rather than lower
+`--enc-window-sec`: `chunk_sec` is a pure scheduling knob with no quality cost,
+while a smaller encoder window also reduces the model's per-token attention
+context. Past the headroom point further increases just add latency, since
+each chunk's audio must arrive before its tokens emit.
 
 ### Monitor Mode (`--monitor`)
 

--- a/main.c
+++ b/main.c
@@ -58,6 +58,9 @@ static void usage(const char *prog) {
     fprintf(stderr, "  -W <secs>     Segment-cutting silence search window ± seconds (default: 3.0)\n");
     fprintf(stderr, "  --stream      Streaming mode: process in chunks with prefix rollback\n");
     fprintf(stderr, "  --stream-max-new-tokens <n>  Max generated tokens per stream step (default: 32)\n");
+    fprintf(stderr, "  --stream-chunk-sec <secs>  Streaming chunk size in seconds (1..8, default 2)\n");
+    fprintf(stderr, "                             Raise on larger models / slower hardware if per-chunk\n");
+    fprintf(stderr, "                             processing > chunk_sec (display latency grows over time)\n");
     fprintf(stderr, "  --enc-window-sec <secs>    Encoder attention window in seconds (1..8, default 8)\n");
     fprintf(stderr, "  --past-text <yes|no|auto>  Reuse previously decoded text as context for the next\n");
     fprintf(stderr, "                             segment/chunk (continuity bias; auto=yes for --stream)\n");
@@ -82,6 +85,7 @@ int main(int argc, char **argv) {
     float search_sec = -1;  /* -1 = use default (3) */
     int stream_mode = 0;
     int stream_max_new_tokens = -1; /* -1 = use default (32) */
+    float stream_chunk_sec = -1; /* -1 = use default (2s) */
     float enc_window_sec = -1;   /* -1 = use default (8s) */
     const char *prompt_text = NULL;
     const char *force_language = NULL;
@@ -104,6 +108,8 @@ int main(int argc, char **argv) {
             stream_mode = 1;
         } else if (strcmp(argv[i], "--stream-max-new-tokens") == 0 && i + 1 < argc) {
             stream_max_new_tokens = atoi(argv[++i]);
+        } else if (strcmp(argv[i], "--stream-chunk-sec") == 0 && i + 1 < argc) {
+            stream_chunk_sec = (float)atof(argv[++i]);
         } else if (strcmp(argv[i], "--enc-window-sec") == 0 && i + 1 < argc) {
             enc_window_sec = (float)atof(argv[++i]);
         } else if (strcmp(argv[i], "--past-text") == 0 && i + 1 < argc) {
@@ -147,6 +153,10 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Error: --enc-window-sec must be in [1, 8], got %.3f\n", enc_window_sec);
         return 1;
     }
+    if (stream_chunk_sec >= 0 && (stream_chunk_sec < 1.0f || stream_chunk_sec > 8.0f)) {
+        fprintf(stderr, "Error: --stream-chunk-sec must be in [1, 8], got %.3f\n", stream_chunk_sec);
+        return 1;
+    }
     if (stream_max_new_tokens == 0 || stream_max_new_tokens < -1) {
         fprintf(stderr, "Error: --stream-max-new-tokens must be > 0\n");
         return 1;
@@ -180,6 +190,7 @@ int main(int argc, char **argv) {
         ctx->config.enc_n_window_infer = window_frames;
     }
     if (stream_max_new_tokens > 0) ctx->stream_max_new_tokens = stream_max_new_tokens;
+    if (stream_chunk_sec >= 0) ctx->stream_chunk_sec = stream_chunk_sec;
     if (past_text_conditioning_mode >= 0)
         ctx->past_text_conditioning = past_text_conditioning_mode;
     else if (stream_mode)


### PR DESCRIPTION
Exposes `stream_chunk_sec` as `--stream-chunk-sec` (range `1..8`, default
unchanged at 2). Previously hardcoded, only tunable by recompiling.

Useful when per-chunk processing approaches `chunk_sec` (e.g. 1.7B on slower
hardware). Counterintuitively, raising it from 2 to 4 in this regime **lowers**
on-screen latency by several seconds: the added per-chunk floor delay is more
than offset by the eliminated backlog.

This makes `--stream-chunk-sec` preferable to `--enc-window-sec` for latency
control near 1x realtime — `chunk_sec` has no quality cost, while a smaller
encoder window also reduces the model's per-token attention context.